### PR TITLE
Add JSON Text instance for (de)serializing Text strings

### DIFF
--- a/Text/JSON.hs
+++ b/Text/JSON.hs
@@ -70,6 +70,7 @@ import qualified Data.Map as M
 import qualified Data.IntMap as IntMap
 
 import qualified Data.Array as Array
+import qualified Data.Text as T
 
 ------------------------------------------------------------------------
 
@@ -419,6 +420,15 @@ instance JSON S.ByteString where
 instance JSON L.ByteString where
   showJSON = encJSString L.unpack
   readJSON = decJSString "Lazy.ByteString" (return . L.pack)
+
+-- -----------------------------------------------------------------
+-- Data.Text
+
+instance JSON T.Text where
+  readJSON (JSString s) = return (T.pack . fromJSString $ s)
+  readJSON _            = mkError "Unable to read JSString"
+  showJSON              = JSString . toJSString . T.unpack
+
 
 -- -----------------------------------------------------------------
 -- Instance Helpers

--- a/json.cabal
+++ b/json.cabal
@@ -97,7 +97,7 @@ library
     else
       build-depends:    base >= 3
 
-    build-depends:   array, containers, bytestring, mtl
+    build-depends:   array, containers, bytestring, mtl, text
 
     if flag(parsec)
       build-depends:    parsec


### PR DESCRIPTION
Add a Data.Text JSON instance to make it possible to serialize and
deserialize data types containing Data.Text strings.

Currently only Strings are supported which makes it cumbersome to use
Data.Text strings together with the json library.

This change adds a dependency to the 'text' library which is nowadays
considered stable & the de facto way to work with unicode strings.

Example usage:

``` haskell

import Control.Applicative
import Text.JSON
import qualified Data.Text as T

data Foo = Foo T.Text
           deriving (Show)

instance JSON Foo where
  readJSON object = do
    obj <- readJSON object
    Foo <$> valFromObj "foo" obj

  showJSON (Foo s) =
    makeObj [("foo", showJSON s)]

test1 = "[{ \"foo\": \"bar\" }]"

parseFoo :: String -> [Foo]
parseFoo s = either (const []) id (resultToEither . decode $ s)

main :: IO ()
main = do
  putStrLn $ encode (Foo (T.pack "jope"))
  print $ parseFoo test1
```

Outputs:

```
nurpax@nurpax:~/dev/json-dev$ ./dist/build/jsontest/jsontest
{"foo":"jope"}
[Foo "bar"]
```
