### PR TITLE
GHC 7.10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
  - GHCVER=7.2.2
  - GHCVER=7.4.2
  - GHCVER=7.6.3
- - GHCVER=7.8.3
+ - GHCVER=7.8.4
  - GHCVER=7.10.1
  - GHCVER=head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
  - GHCVER=7.4.2
  - GHCVER=7.6.3
  - GHCVER=7.8.3
+ - GHCVER=7.10.1
  - GHCVER=head
 
 before_install:

--- a/Text/JSON/String.hs
+++ b/Text/JSON/String.hs
@@ -48,6 +48,7 @@ import Text.JSON.Types (JSValue(..),
                         JSObject, toJSObject, fromJSObject)
 
 import Control.Monad (liftM, ap)
+import Control.Applicative((<$>))
 import qualified Control.Applicative as A
 import Data.Char (isSpace, isDigit, digitToInt)
 import Data.Ratio (numerator, denominator, (%))
@@ -85,9 +86,6 @@ getInput    = GetJSON (\s -> Right (s,s))
 
 setInput   :: String -> GetJSON ()
 setInput s  = GetJSON (\_ -> Right ((),s))
-
-(<$>) :: Functor f => (a -> b) -> f a -> f b
-x <$> y = fmap x y
 
 -------------------------------------------------------------------------
 


### PR DESCRIPTION
GHC 7.10 RC3 moved `<$>` into the Prelude, this patch fixes the change and continues to work with all previous versions.