### PR TITLE
Use MonadFail rather than Monad.fail.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+NEXT
+  * Add `MonadFail` instances and only define `Monad.fail` on pre-8.6 GHCs.
+
 Version 0.9.1
   * Merge-in contributions from Neil Mitchell to support GHC 7.10
 

--- a/Text/JSON.hs
+++ b/Text/JSON.hs
@@ -46,6 +46,7 @@ import Text.JSON.String
 import Data.Int
 import Data.Word
 import Control.Monad(liftM,ap,MonadPlus(..))
+import qualified Control.Monad.Fail as Fail
 import Control.Applicative
 
 import qualified Data.ByteString.Char8 as S
@@ -137,9 +138,14 @@ instance MonadPlus Result where
 
 instance Monad Result where
   return x      = Ok x
-  fail x        = Error x
+#if !(MIN_VERSION_base(4,13,0))
+  fail x        = Fail.fail x
+#endif
   Ok a >>= f    = f a
   Error x >>= _ = Error x
+
+instance Fail.MonadFail Result where
+  fail x        = Error x
 
 -- | Convenient error generation
 mkError :: String -> Result a

--- a/json.cabal
+++ b/json.cabal
@@ -115,5 +115,5 @@ library
   if flag(mapdict)
      cpp-options:     -DMAP_AS_DICT
 
-
-
+  if !(impl(ghc >= 8.0))
+    build-depends:    fail


### PR DESCRIPTION
This is needed for GHC 8.8 compatibility, but the instances work fine
on older GHCs (which might need the `fail` package, but that's OK).