### PR TITLE
Correct `base` lower bound

### DIFF
--- a/json.cabal
+++ b/json.cabal
@@ -94,12 +94,12 @@ library
 
   if flag(split-base)
     if flag(generic)
-      build-depends:    base >=4 && <5, syb >= 0.3.3
+      build-depends:    base >=4.9 && <5, syb >= 0.3.3
 
       exposed-modules:  Text.JSON.Generic
       Cpp-Options:      -DBASE_4
     else
-      build-depends:    base >= 3
+      build-depends:    base >= 3 && <4
 
     build-depends:   array, containers, bytestring, mtl, text
 


### PR DESCRIPTION
The `Control.Monad.Fail` is only in `base` since base-4.9. Fixes

```
Text/JSON.hs:48:18:
    Could not find module ‘Control.Monad.Fail’
```

Alternatively you could add a (conditional) dependency on `fail`

```
if !impl(ghc >= 8.0)
  build-depends:
    fail                 >= 4.9.0.0 && < 4.10
```

You might need to change the code too, I haven't tried that on `json` myself.

---

I'd also recommend to
- remove `split-base` flag, it serves no purpose anymore. Ditto `generic`
- Also it's recommended to specify `manual: True` or `manual: False` explicitly for flags. The default is automatic, so `cabal` solver could on its will disable `pretty` and `parsec`, even the intended default is to have them.

---

I made a revision to released version on Hackage: https://hackage.haskell.org/package/json-0.10/revisions/ so the `json-0.10` has now correct metadata.