### PR TITLE
fix `Text.JSON.Parsec.p_string` losing leading spaces

### DIFF
--- a/Text/JSON/Parsec.hs
+++ b/Text/JSON/Parsec.hs
@@ -49,7 +49,7 @@ p_array           = between (tok (char '[')) (tok (char ']'))
                   $ p_jvalue `sepBy` tok (char ',')
 
 p_string         :: CharParser () String
-p_string          = between (tok (char '"')) (tok (char '"')) (many p_char)
+p_string          = between (char '"') (tok (char '"')) (many p_char)
   where p_char    =  (char '\\' >> p_esc)
                  <|> (satisfy (\x -> x /= '"' && x /= '\\'))
 


### PR DESCRIPTION
`Text.JSON.Parsec.p_string` skipped spaces after the opening double quotes. Those spaces must actually be part of the parsing result, so do not skip them.